### PR TITLE
Only show the cheers for the last week in the tag lists, e.g. #london

### DIFF
--- a/app/controllers/shoutouts_controller.rb
+++ b/app/controllers/shoutouts_controller.rb
@@ -21,7 +21,9 @@ class ShoutoutsController < ApplicationController
 
   def tag
     @tag = params[:tag]
-    @shoutouts = Shoutout.tagged_with(params[:tag]).order('created_at DESC')
+    @shoutouts = Shoutout.since_sunday_morning
+      .tagged_with(params[:tag])
+      .order('created_at DESC')
   end
 
   def create

--- a/spec/features/shoutout_spec.rb
+++ b/spec/features/shoutout_spec.rb
@@ -36,6 +36,16 @@ RSpec.feature "Shouting out with tags" do
     expect(page).to have_selector(:link_or_button, '#london')
   end
 
+  specify "only shows shoutouts for the last week" do
+    shoutout = create(:shoutout,
+                      message: "Old Shoutout",
+                      tag_list: "london",
+                      created_at: 7.days.ago)
+
+    visit('/tag/london')
+    expect(page).to_not have_content "Old Shoutout"
+  end
+
   specify "tag for users location is automatically appended" do
     user = create(:user, location: 'london')
     send_shoutout(from: user.name, message: '@person thanks')


### PR DESCRIPTION
Currently these list just show all matching cheers (shoutouts) for the tag - it is not limited to the last working week.