### PR TITLE
Use rails postgres db default in dev and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ Cheers
 =======
 
 ### Setting up the database
-Add a file `.env.local` to the root folder and configure `DATABASE_URL` to match your environment.
-Leave the database name out of the URL; rails will fill it according to the database.yml config.
+Must have postgresql installed.
 
 ### Downloading and importing a production backup from Heroku
 https://gist.github.com/wrburgess/5528649

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,6 @@
 default: &default
   adapter: postgresql
   encoding: utf8
-  url: <%= ENV.fetch("DATABASE_URL") %>
   pool: 5
 
 development:
@@ -16,4 +15,3 @@ production:
   <<: *default
   url:  <%= ENV["DATABASE_URL"] %>
   pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
-


### PR DESCRIPTION
Without setting database environment variable in database.yml
rails will automatically connect to localhost on port 5432

This means that we don't need to configure .env.local when setting
up the project.

(Charlie and I thought this would make it easier for newcomers on the project as it is not usually a requirement to set the database_url in development)