### PR TITLE
Fix bug in cheers app that prevents user cheers

### DIFF
--- a/app/controllers/shoutouts_controller.rb
+++ b/app/controllers/shoutouts_controller.rb
@@ -32,7 +32,10 @@ class ShoutoutsController < ApplicationController
       end
     end
 
-    if params[:text].include?(params[:user_name])
+    recipients = params[:text]
+                    .scan(/(@(\w+|\.)+)/)
+                    .map(&:first).map { |r| r[1..-1] }
+    if (recipients.include?(params[:user_name]))
       return render text: "Share the love, you can't cheer for yourself! #{root_url}help"
     elsif !params[:text].match(/@\w+/)
       return render text: "Share the love! You need to mention someone. #{root_url}help"
@@ -43,9 +46,7 @@ class ShoutoutsController < ApplicationController
     shoutout = Shoutout.create(
       sender: params[:user_name],
       message: message,
-      recipients: message
-                    .scan(/(@(\w+|\.)+)/)
-                    .map(&:first).map { |r| r[1..-1] },
+      recipients: recipients,
       tag_list: message
                   .scan(/(#(\w+)+)/)
                   .map(&:first).map { |t| t[1..-1] }.join(', ')

--- a/spec/features/shoutout_spec.rb
+++ b/spec/features/shoutout_spec.rb
@@ -13,6 +13,20 @@ RSpec.feature "Shouting out to another person" do
   specify "responds appropriately when attempting to self shoutout" do
     response = send_shoutout(from: "Jeff", message: "thx @Jeff")
     expect(response.body).to include("Share the love, you can't cheer for yourself!")
+    response = send_shoutout(from: "Jeff", message: "thx @Jeff for all the cheese")
+    expect(response.body).to include("Share the love, you can't cheer for yourself!")
+    response = send_shoutout(from: "Jeff", message: "thx @Jeff, that cheese was great!")
+    expect(response.body).to include("Share the love, you can't cheer for yourself!")
+  end
+
+  specify "accepts words containing name in shoutout text" do
+    response = send_shoutout(from: "tim", message: "Thx @Bob for helping with the estimate!")
+    expect(response.body).to include('You cheered for Bob! Visit http://example.org/ to see your cheer.')
+  end
+
+  specify "accepts other users that also contain name in shoutout text" do
+    response = send_shoutout(from: "tim", message: "Thx @timothy for helping with the estimate!")
+    expect(response.body).to include('You cheered for timothy! Visit http://example.org/ to see your cheer.')
   end
 
   specify "responds appropriately when no one is mentioned in message" do


### PR DESCRIPTION
Currently if a user sends a cheer that has words that contain their
username, the cheer is blocked. Also different users that have names
where one is a subset of another would also be blocked. This commit aims
to rectify that by building a list of the recipients and checking for
the username.