### PR TITLE
Ping the user directly when they have received a shoutout

### DIFF
--- a/app/controllers/shoutouts_controller.rb
+++ b/app/controllers/shoutouts_controller.rb
@@ -55,15 +55,19 @@ class ShoutoutsController < ApplicationController
     if shoutout.tag_list.include?("london")
       slack.post_message(Settings.slack.london, cheered_notification_message_for_channel(message))
     end
-
     if shoutout.tag_list.include?("capetown")
       slack.post_message(Settings.slack.cape_town, cheered_notification_message_for_channel(message))
     end
 
     render text: "You cheered for #{shoutout.recipients.join(' & ')}! Visit #{root_url} to see your cheer."
+    slack.post_direct_message(Settings.slack.token, shoutout.recipients, cheered_notification_message_for_user)
   end
 
   private
+
+  def cheered_notification_message_for_user
+    "Lucky you, you've been cheered. Would you like to cheer in return?"
+  end
 
   def cheered_notification_message_for_channel(message)
     "@#{params[:user_name]} cheered: #{message}\nSee it, and other cheers at #{root_url}!"

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -2,7 +2,17 @@ class SlackService
   def initialize(client = Slack::Client.new)
     @client = client
   end
+
   def post_message(channel, message)
     @client.chat_postMessage(channel: channel, text: message, as_user: true)
+  end
+
+  def post_direct_message(token, users, message)
+    members = @client.users_list(token: token)
+    user_id_array = []
+    members["members"].each do |key, value|
+      users.each { |user| user_id_array << key["id"] if key["name"] == user }
+    end
+    user_id_array.each { |id| post_message(id, message) }
   end
 end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -11,4 +11,15 @@ RSpec.describe SlackService, type: :service do
       subject.post_message('london', 'cheers!')
     end
   end
+
+  describe "Posting a message to a cheered user" do
+    let (:client) { double(:slack_client) }
+    subject { described_class.new(client) }
+
+    it "should call cheered user with expected parameters" do
+      allow(client).to receive(:users_list).with(token: 'not_a_token').and_return({"members"=>[{'name'=>'user', 'id'=>'1'}]})
+      expect(client).to receive(:chat_postMessage).with(channel: '1', text: 'you got cheered!', as_user: true)
+      subject.post_direct_message('not_a_token', ['user'], 'you got cheered!')
+    end
+  end
 end


### PR DESCRIPTION
 User gets messaged directly on slack to tell them they have been cheered, and prompts them to cheer someone else.  
  - Added post_direct_message method to slack_service
  - This is called in shoutouts_controller